### PR TITLE
Fix worldgen issues

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -17,6 +17,6 @@ fabric_version=0.83.1+1.20.1
 # https://github.com/DawnTeamMC/DawnAPI
 dawn_version=5.0.0
 # https://maven.terraformersmc.com/releases/com/terraformersmc/biolith
-biolith_version=1.0.0-alpha.7
+biolith_version=1.0.0-alpha.8
 # https://www.curseforge.com/minecraft/mc-mods/columns
 columns_version=3836307


### PR DESCRIPTION
Biolith alpha-7 has an issue with biomes when you don't close your Minecraft instance. That should fix it.